### PR TITLE
people without surname, places and corporate names are now OK, I hope

### DIFF
--- a/exporters/letters/xq/solrize.xsl
+++ b/exporters/letters/xq/solrize.xsl
@@ -461,7 +461,7 @@
 	  <xsl:variable name="role">
 	    <xsl:value-of select="@type"/>
 	  </xsl:variable>
-	  <xsl:for-each select="t:placeName">
+	  <xsl:for-each select="t:placeName[text()]">
 	    <xsl:element name="field">
 	      <xsl:attribute name="name">
 		<xsl:value-of select="concat($role,'_location_ssim')"/>
@@ -558,7 +558,7 @@
 	<xsl:attribute name="name">
 	  <xsl:value-of select="concat('sortby_',$field,'_ssi')"/>
 	</xsl:attribute>
-	<xsl:value-of select="$value"/>
+	<xsl:value-of select="normalize-space($value)"/>
       </xsl:element>
     </xsl:if>
 
@@ -585,18 +585,18 @@
 	    <xsl:value-of select="t:resp"/>
 	  </xsl:variable>
 	  <xsl:for-each select="t:name">
-	  <xsl:element name="field">
-	    <xsl:attribute name="name">
-	      <xsl:value-of select="concat($field,'_ssim')"/>
-	    </xsl:attribute>
-	    <xsl:value-of select="t:surname"/><xsl:text>, </xsl:text><xsl:value-of select="t:forename"/>
+	    <xsl:element name="field">
+	      <xsl:attribute name="name">
+		<xsl:value-of select="concat($field,'_ssim')"/>
+	      </xsl:attribute>
+	      <xsl:if test="t:surname[text()]"><xsl:value-of select="t:surname"/><xsl:text>, </xsl:text></xsl:if><xsl:value-of select="t:forename"/>
 	    </xsl:element>
 
 	    <xsl:element name="field">
 	      <xsl:attribute name="name">
 		<xsl:value-of select="concat($field,'_tesim')"/>
 	      </xsl:attribute>
-              <xsl:value-of select="t:forename"/><xsl:text> </xsl:text><xsl:value-of select="t:surname"/>
+              <xsl:value-of select="t:forename"/><xsl:if test="t:surname[text()]"><xsl:text> </xsl:text></xsl:if><xsl:value-of select="t:surname"/>
 	    </xsl:element>
 
 	    <xsl:element name="field">
@@ -631,7 +631,6 @@
 	</xsl:attribute>
 	<xsl:value-of select="."/>
       </xsl:element>
-
 
     </xsl:for-each>
   </xsl:template>


### PR DESCRIPTION
Dear @xenma and @davidgrove73 

The construct

<t:location type="sender" xml:id="idm8492c90d-9cdb-495c-91d4-fa87cc12a4c2">
    <t:placeName/>
</t:location>

in 

http://valhal-test-01.kb.dk:8080/exist/rest/db/letter_books/000743146/000743146_001.xml

No longer create empty sender_location_ssim

http://valhal-test-01.kb.dk:8080/exist/rest/db/letter_books/present.xq?doc=000743146_001.xml&c=/db/letter_books/000743146&op=solrize&id=L0007431460010023

Space is trimmed from start and end of strings

Things lacking surnames are no longer  creating " , forename" problems.

Cheers