### PR TITLE
Fix holberg

### DIFF
--- a/STATUS-and-ROADMAP/README.md
+++ b/STATUS-and-ROADMAP/README.md
@@ -4,7 +4,7 @@ The joint corpus for ADL and other text sources can be delivered
 through one head, with a common oesophagus but separate guts.
 
 
-## Corpora
+## Corpora and capabilities
 
 Different encoding practices (or even entirely different data
 encodings) yields documents with different capabilities.

--- a/exporters/adl/render.xsl
+++ b/exporters/adl/render.xsl
@@ -2,8 +2,37 @@
 <xsl:transform version="2.0"
 	       xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	       xmlns:t="http://www.tei-c.org/ns/1.0"
+	       xmlns:fn="http://www.w3.org/2005/xpath-functions"
 	       exclude-result-prefixes="t">
 
   <xsl:import href="../render-global.xsl"/>  
+
+   <xsl:template name="inferred_path">
+     <xsl:param name="document" select="$doc"/>
+     <xsl:variable name="frag">
+       <xsl:choose>
+	 <xsl:when test="contains($document,'#')">
+	   <xsl:value-of select="fn:replace(substring-after($document,'#'),':.*$','')"/>
+	 </xsl:when>
+	 <xsl:otherwise>root</xsl:otherwise>
+       </xsl:choose>
+     </xsl:variable>
+     <xsl:variable name="f">
+       <xsl:choose>
+	 <xsl:when test="$frag = 'root'">-</xsl:when>
+	 <xsl:otherwise>-root#</xsl:otherwise>
+       </xsl:choose>
+     </xsl:variable>
+     <xsl:text>/text/</xsl:text><xsl:value-of select="replace(concat($c,'-',fn:lower-case(fn:replace($document,'(\.xml)|(\.page).*$','')),$f,$frag),'/','-')"/>
+   </xsl:template>
+
+  <xsl:template name="make-href">
+    <xsl:call-template name="inferred_path">
+      <xsl:with-param name="document" select="@target"/>
+    </xsl:call-template>
+  </xsl:template>
+
+
+
 
 </xsl:transform>

--- a/exporters/common/apparatus-global.xsl
+++ b/exporters/common/apparatus-global.xsl
@@ -12,11 +12,33 @@
   <xsl:variable name="iip_baseuri"  select="'http://kb-images.kb.dk/public/sks/'"/>
   <xsl:variable name="iiif_suffix" select="'/full/full/0/native.jpg'"/>
 
-  <xsl:template match="t:corr">
+  <xsl:template mode="text" match="t:corr">
     <span title="rættelse">
+      <xsl:call-template name="add_id"/>
       <xsl:apply-templates/>
     </span>
   </xsl:template>
+
+  <xsl:template mode="apparatus" match="t:corr">
+    <span title="rættelse">
+      <xsl:call-template name="add_id"/>
+      <xsl:apply-templates/>
+      <xsl:if test="@wit">
+	<xsl:call-template name="witness"/>
+      </xsl:if>
+      <xsl:if test="@resp">
+	<xsl:text>
+	</xsl:text>
+	<xsl:call-template name="witness">
+	  <xsl:with-param name="wit" select="@resp"/>
+	</xsl:call-template>
+      </xsl:if>
+      <xsl:if test="@evidence">
+	[<xsl:value-of select="@evidence"/>]
+      </xsl:if>
+    </span>
+  </xsl:template>
+
 
   <xsl:template match="t:add">
     <span title="tillæg">
@@ -127,10 +149,30 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="t:lem">
+  <xsl:template mode="text" match="t:lem">
     <xsl:element name="span">
       <xsl:call-template name="add_id"/>
       <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template mode="apparatus" match="t:lem">
+    <xsl:element name="span">
+      <xsl:call-template name="add_id"/>
+      <xsl:apply-templates/>]<xsl:text> 
+      </xsl:text>
+      <xsl:choose>
+	<xsl:when test="@wit">
+	  <xsl:call-template name="witness"/>
+	</xsl:when>
+	<xsl:when test="@resp">
+	  <xsl:call-template name="witness">
+	    <xsl:with-param name="wit" select="@resp"/>
+	  </xsl:call-template>
+	</xsl:when>
+      </xsl:choose>
+      <xsl:text> 
+      </xsl:text>
     </xsl:element>
   </xsl:template>
 
@@ -142,61 +184,89 @@
   </xsl:template>
 
   <xsl:template match="t:app">
+    <!-- i class="fa fa-info-circle" aria-hidden="true"><xsl:comment> * </xsl:comment></i> absent_friend  -->
+    <xsl:apply-templates mode="text" select="t:lem"/>
+    <xsl:element name="span">
+      <xsl:call-template name="apparatus-marker"><xsl:with-param name="marker">&#128712; </xsl:with-param></xsl:call-template>
+    </xsl:element>
+
+    <span style="background-color:Aquamarine;display:none;">
+      <xsl:call-template name="add_id"/>
+      <xsl:apply-templates mode="apparatus" select="t:lem"/>
+      <xsl:for-each select="t:rdg|t:rdgGrp|t:corr">
+	<xsl:apply-templates mode="apparatus"  select="."/><xsl:if test="position() &lt; last()"><xsl:text>; </xsl:text></xsl:if>
+      </xsl:for-each>
+    </span>
+
+  </xsl:template>
+
+  <xsl:template name="apparatus-marker">
+    <xsl:param name="marker" select="'missing marker'"/>
     <xsl:variable name="idstring">
       <xsl:value-of select="translate(@xml:id,'-;.','___')"/>
     </xsl:variable>
     <xsl:variable name="note">
       <xsl:value-of select="concat('apparatus',$idstring)"/>
     </xsl:variable>
-    <xsl:apply-templates select="t:lem"/>
-    <xsl:element name="sup">
-      <xsl:attribute name="style">text-indent: 0;</xsl:attribute>
-      <script>
-	var <xsl:value-of select="concat('disp',$idstring)"/>="none";
-	function <xsl:value-of select="$note"/>() {
-	var ele = document.getElementById("<xsl:value-of select="@xml:id"/>");
-	if(<xsl:value-of select="concat('disp',$idstring)"/>=="none") {
-	ele.style.display="inline";
-	<xsl:value-of select="concat('disp',$idstring)"/>="inline";
-	} else {
-	ele.style.display="none";
-	<xsl:value-of select="concat('disp',$idstring)"/>="none";
-	}
-	}
-      </script>
-      <xsl:element name="a">
-	<xsl:attribute name="title">Tekstkritik</xsl:attribute>
-	<xsl:attribute name="onclick"><xsl:value-of select="$note"/>();</xsl:attribute>
-	<i class="fa fa-info-circle" aria-hidden="true"><xsl:comment> * </xsl:comment></i>
-      </xsl:element>
+    <xsl:attribute name="style">text-indent: 0;</xsl:attribute>
+    <script>
+      var <xsl:value-of select="concat('disp',$idstring)"/>="none";
+      function <xsl:value-of select="$note"/>() {
+      var ele = document.getElementById("<xsl:value-of select="@xml:id"/>");
+      if(<xsl:value-of select="concat('disp',$idstring)"/>=="none") {
+      ele.style.display="inline";
+      <xsl:value-of select="concat('disp',$idstring)"/>="inline";
+      } else {
+      ele.style.display="none";
+      <xsl:value-of select="concat('disp',$idstring)"/>="none";
+      }
+      }
+    </script>
+    <xsl:element name="a">
+      <xsl:attribute name="title">Tekstkritik</xsl:attribute>
+      <xsl:attribute name="onclick"><xsl:value-of select="$note"/>();</xsl:attribute>
+      <xsl:value-of select="$marker"/>
     </xsl:element>
-    <span style="background-color:Aquamarine;display:none;">
-      <xsl:call-template name="add_id"/>
-      <xsl:apply-templates select="t:rdg|t:rdgGrp|t:corr"/>
-    </span>
   </xsl:template>
 
   <xsl:template match="t:sic">
+    <xsl:apply-templates/> [<em>sic!</em>]
   </xsl:template>
 
-  <xsl:template match="t:rdg">
-    <xsl:if test="t:sic/@rendition = '#so'"><xsl:text> Således også: </xsl:text></xsl:if>
+  <xsl:template  mode="apparatus"  match="t:rdg">
     <xsl:element name="span">
+      <xsl:apply-templates  mode="apparatus" />
       <xsl:if test="@wit">
 	<xsl:call-template name="witness"/>
-      </xsl:if><xsl:choose><xsl:when test="t:sic/@rendition = '#so'"><xsl:text> </xsl:text></xsl:when><xsl:otherwise><xsl:text>: </xsl:text></xsl:otherwise></xsl:choose>
-      <xsl:apply-templates/><xsl:if test="@evidence">[<xsl:value-of select="@evidence"/>]</xsl:if>
+      </xsl:if>
+      <xsl:if test="@resp">
+	<xsl:text>
+	</xsl:text>
+	<xsl:call-template name="witness">
+	  <xsl:with-param name="wit" select="@resp"/>
+	</xsl:call-template>
+      </xsl:if>
+      <xsl:if test="@evidence">
+	[<xsl:value-of select="@evidence"/>]
+      </xsl:if>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template  mode="text"  match="t:rdg">
+    <xsl:element name="span">
+      <xsl:apply-templates />
     </xsl:element>
   </xsl:template>
 
   <xsl:template name="witness">
-    <xsl:comment> Witness <xsl:value-of select="@wit"/> </xsl:comment>
+    <xsl:param name="wit" select="@wit"/>
+    <xsl:comment> Witness <xsl:value-of select="$wit"/> </xsl:comment>
     <xsl:variable name="witnesses">
       <xsl:copy-of select="/t:TEI//t:listWit"/>
     </xsl:variable>
-    <xsl:for-each select="fn:tokenize(@wit,'\s+')">
-      <xsl:variable name="witness"><xsl:value-of select="normalize-space(substring-after(.,'#'))"/></xsl:variable>
-      <xsl:element name="span">
+    <xsl:for-each select="fn:tokenize($wit,'\s+')">
+      <xsl:variable name="witness"><xsl:choose><xsl:when test="contains(.,'#')"><xsl:value-of select="normalize-space(substring-after(.,'#'))"/></xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose></xsl:variable>
+      <xsl:element name="em">
 	<xsl:attribute name="title">
 	  <xsl:value-of select="$witnesses//t:witness[@xml:id=$witness]"/>
 	</xsl:attribute>

--- a/exporters/common/apparatus-global.xsl
+++ b/exporters/common/apparatus-global.xsl
@@ -75,9 +75,7 @@
     </xsl:element>
   </xsl:template>
 
-
-
-  <xsl:template match="t:ref">
+  <xsl:template match="t:ref[@type='commentary']">
     <xsl:element name="a">
       <xsl:if test="@type='commentary'"><xsl:attribute name="title">Kommentar</xsl:attribute></xsl:if>
       <xsl:if test="@target">

--- a/exporters/common/open-seadragon-config.xq
+++ b/exporters/common/open-seadragon-config.xq
@@ -90,7 +90,7 @@ declare function local:get-pages(
 	    else 
 	     let $uri_path := 
 	         if($doc//t:graphic[@xml:id=$pid]/@url) then fn:replace($doc//t:graphic[@xml:id=$pid]/@url,"(^.*geService/)(.*)(.jpg)","$2")
-                 else concat("/public",$pid)
+                 else concat("public/",$pid)
              return  string-join(("http://kb-images.kb.dk",$uri_path,"info.json"),'/')
 
 };

--- a/exporters/common/open-seadragon-config.xq
+++ b/exporters/common/open-seadragon-config.xq
@@ -84,9 +84,15 @@ declare function local:get-pages(
                else string-join(("http://kb-images.kb.dk/public",$p/@facs/string(),"info.json"),'/')
 	else
 	  for $p in $doc//t:pb
+	  let $pid := $p/@facs/string()
 	  return  
             if($p/@rend = 'missing') then $missing
-            else string-join(("http://kb-images.kb.dk/public",$p/@facs/string(),"info.json"),'/')
+	    else 
+	     let $uri_path := 
+	         if($doc//t:graphic[@xml:id=$pid]/@url) then fn:replace($doc//t:graphic[@xml:id=$pid]/@url,"(^.*geService/)(.*)(.jpg)","$2")
+                 else $pid
+             return  string-join(("http://kb-images.kb.dk/public",$uri_path,"info.json"),'/')
+
 };
 
 let $doc := doc(concat("./",$c,"/",$document))

--- a/exporters/common/open-seadragon-config.xq
+++ b/exporters/common/open-seadragon-config.xq
@@ -90,8 +90,8 @@ declare function local:get-pages(
 	    else 
 	     let $uri_path := 
 	         if($doc//t:graphic[@xml:id=$pid]/@url) then fn:replace($doc//t:graphic[@xml:id=$pid]/@url,"(^.*geService/)(.*)(.jpg)","$2")
-                 else $pid
-             return  string-join(("http://kb-images.kb.dk/public",$uri_path,"info.json"),'/')
+                 else concat("/public",$pid)
+             return  string-join(("http://kb-images.kb.dk",$uri_path,"info.json"),'/')
 
 };
 

--- a/exporters/common/render-global.xsl
+++ b/exporters/common/render-global.xsl
@@ -3,6 +3,7 @@
 <xsl:stylesheet 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:t="http://www.tei-c.org/ns/1.0"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
     exclude-result-prefixes="t"
     version="2.0">
 
@@ -276,10 +277,18 @@
 
   <xsl:template match="t:ref">
     <xsl:choose>
+      <xsl:when test="fn:matches(@target,'^https?')">
+	<xsl:element name="a">
+	  <xsl:attribute name="href">
+	    <xsl:value-of select="@target/string()"/>
+	  </xsl:attribute> 
+	  <xsl:apply-templates/>
+	</xsl:element>
+      </xsl:when>
       <xsl:when test="contains(@target,'AdlPageRef.xsql')">
 	<xsl:apply-templates/>
       </xsl:when>
-      <xsl:when test="contains(@target,'../texts/')">
+      <!-- xsl:when test="contains(@target,'../texts/')">
 	<xsl:element name="a">
 	  <xsl:call-template name="add_id"/>
 	  <xsl:variable name="frag">
@@ -294,7 +303,7 @@
 	  </xsl:comment>
 	  <xsl:apply-templates/>
 	</xsl:element>
-      </xsl:when>
+      </xsl:when -->
       <xsl:otherwise>
 	<xsl:element name="a">
 	  <xsl:if test="@target">

--- a/exporters/common/render-global.xsl
+++ b/exporters/common/render-global.xsl
@@ -308,7 +308,7 @@
 	<xsl:element name="a">
 	  <xsl:if test="@target">
 	    <xsl:attribute name="href">
-	      <xsl:apply-templates select="@target"/>
+	      <xsl:call-template name="make-href"/>
 	    </xsl:attribute> 
 	  </xsl:if>
 	  <xsl:call-template name="add_id"/>

--- a/exporters/holberg/render.xsl
+++ b/exporters/holberg/render.xsl
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <xsl:transform version="2.0"
 	       xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	       xmlns:fn="http://www.w3.org/2005/xpath-functions"
 	       xmlns:t="http://www.tei-c.org/ns/1.0"
 	       exclude-result-prefixes="t">
   
@@ -12,8 +13,6 @@
       <xsl:apply-templates mode="gettext"  select="."/><xsl:if test="position() &lt; last()">; </xsl:if>
     </xsl:for-each>
   </xsl:param>
-
-
 
   <xsl:template match="t:pb">
     <xsl:variable name="first">
@@ -32,6 +31,21 @@
 	</xsl:if>
       </xsl:element>
     </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="t:ref[@type='komm']">
+    <xsl:if test="contains(@type,'komm') and contains(@path,'komm')">
+      <xsl:if test="contains($doc,fn:lower-case(fn:replace(@target,'.page.*$','')))">
+	<a href="{fn:replace(@target,'^(.*#[^:]*?:)','#')}"><xsl:apply-templates/></a>
+      </xsl:if>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="t:seg[@type='komm']">
+    <xsl:variable name="href">
+      <xsl:value-of select="concat(fn:replace($path,'-((root)|(shoot).*$)','_komm-root#'),@target)"/>
+    </xsl:variable>
+    <a href="{$href}">&#9658;</a>
   </xsl:template>
 
   <xsl:template name="make-href">

--- a/exporters/holberg/render.xsl
+++ b/exporters/holberg/render.xsl
@@ -45,7 +45,7 @@
     <xsl:variable name="href">
       <xsl:value-of select="concat(fn:replace($path,'-((root)|(shoot).*$)','_komm-root#'),@target)"/>
     </xsl:variable>
-    <a href="{$href}">&#9658;</a>
+    <a title="Kommentar" href="{$href}">&#9658;</a>
   </xsl:template>
 
   <xsl:template name="make-href">

--- a/exporters/holberg/render.xsl
+++ b/exporters/holberg/render.xsl
@@ -48,67 +48,29 @@
     <a title="Kommentar" href="{$href}">&#9658;</a>
   </xsl:template>
 
+   <xsl:template name="inferred_path">
+     <xsl:param name="document" select="$doc"/>
+     <xsl:variable name="frag">
+       <xsl:choose>
+	 <xsl:when test="contains($document,'#')">
+	   <xsl:value-of select="substring-after($document,'#')"/>
+	 </xsl:when>
+	 <xsl:otherwise>root</xsl:otherwise>
+       </xsl:choose>
+     </xsl:variable>
+     <xsl:variable name="f">
+       <xsl:choose>
+	 <xsl:when test="$frag = 'root'">-</xsl:when>
+	 <xsl:otherwise>-shoot-</xsl:otherwise>
+       </xsl:choose>
+     </xsl:variable>
+     <xsl:text>/text/</xsl:text><xsl:value-of select="replace(concat($c,'-',fn:lower-case(fn:replace($document,'(\.xml)|(\.page).*$','')),$f,$frag),'/','-')"/>
+   </xsl:template>
+
   <xsl:template name="make-href">
-
-    <xsl:variable name="target">
-      <xsl:value-of select="translate(@target,$uppercase,$lowercase)"/>
-    </xsl:variable>
-
-    <xsl:choose>
-      <xsl:when test="contains($target,'#') and not(substring-before($target,'#'))">
-	<xsl:value-of select="$target"/>	    
-      </xsl:when>
-      <xsl:otherwise>
-	<xsl:variable name="href">
-	  <xsl:variable name="fragment">
-	    <xsl:if test="contains($target,'#')">
-	      <xsl:value-of select="concat('#',substring-after($target,'#'))"/>
-	    </xsl:if>
-	  </xsl:variable>
-	  <xsl:variable name="file">
-	    <xsl:choose>
-	      <xsl:when test="contains($target,'#')">
-		<xsl:value-of select="substring-before($target,'#')"/>
-	      </xsl:when>
-	      <xsl:otherwise>
-		<xsl:value-of select="$target"/>
-	      </xsl:otherwise>
-	    </xsl:choose>
-	  </xsl:variable>
-	  <xsl:choose>
-	    <xsl:when test="contains($file,'../')">
-	      <xsl:value-of select="concat($c,'-',substring-before(substring-after($file,'../'),'.xml'),'-root',$fragment)"/>
-	    </xsl:when>
-	    <xsl:otherwise>
-	      <xsl:choose>
-		<xsl:when test="contains($path,'-txt')">
-		  <xsl:value-of 
-		      select="concat(substring-before($path,'-txt'),
-			      '-',
-			      substring-before($target,'.xml'),
-			      '-root',
-			      substring-after($target,'.xml'))"/>
-		</xsl:when>
-		<xsl:when test="contains($path,'-kom')">
-		  <xsl:value-of 
-		      select="concat(substring-before($path,'-kom'),'-',substring-before($target,'.xml'),'-root',substring-after($target,'.xml'))"/>
-		</xsl:when>
-		<xsl:when test="contains($path,'-txr')">
-		  <xsl:value-of 
-		      select="concat(substring-before($path,'-txr'),'-',substring-before($target,'.xml'),'-root',substring-after($target,'.xml'))"/>
-		</xsl:when>
-		<xsl:otherwise>
-		  <xsl:value-of select="$target"/>
-		</xsl:otherwise>
-	      </xsl:choose>
-	    </xsl:otherwise>
-	  </xsl:choose>
-	</xsl:variable>
-	<xsl:value-of select="concat($adl_baseuri,'/text/',translate($href,'/','-'))"/>
-      </xsl:otherwise>
-    </xsl:choose>
-
-
+    <xsl:call-template name="inferred_path">
+      <xsl:with-param name="document" select="@target"/>
+    </xsl:call-template>
   </xsl:template>
 
 

--- a/exporters/holberg/render.xsl
+++ b/exporters/holberg/render.xsl
@@ -42,8 +42,11 @@
   </xsl:template>
 
   <xsl:template match="t:seg[@type='komm']">
+    <xsl:variable name="p">
+      <xsl:value-of select="replace($path,'(_overs)|(_mod)','')"/>
+    </xsl:variable>
     <xsl:variable name="href">
-      <xsl:value-of select="concat(fn:replace($path,'-((root)|(shoot).*$)','_komm-root#'),@target)"/>
+      <xsl:value-of select="concat(fn:replace($p,'-((root)|(shoot).*$)','_komm-root#'),@target)"/>
     </xsl:variable>
     <a title="Kommentar" href="{$href}">&#9658;</a>
   </xsl:template>
@@ -53,7 +56,7 @@
      <xsl:variable name="frag">
        <xsl:choose>
 	 <xsl:when test="contains($document,'#')">
-	   <xsl:value-of select="substring-after($document,'#')"/>
+	   <xsl:value-of select="fn:replace(substring-after($document,'#'),':.*$','')"/>
 	 </xsl:when>
 	 <xsl:otherwise>root</xsl:otherwise>
        </xsl:choose>
@@ -61,7 +64,7 @@
      <xsl:variable name="f">
        <xsl:choose>
 	 <xsl:when test="$frag = 'root'">-</xsl:when>
-	 <xsl:otherwise>-shoot-</xsl:otherwise>
+	 <xsl:otherwise>-root#</xsl:otherwise>
        </xsl:choose>
      </xsl:variable>
      <xsl:text>/text/</xsl:text><xsl:value-of select="replace(concat($c,'-',fn:lower-case(fn:replace($document,'(\.xml)|(\.page).*$','')),$f,$frag),'/','-')"/>

--- a/exporters/sks/apparatus.xsl
+++ b/exporters/sks/apparatus.xsl
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<xsl:stylesheet 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:t="http://www.tei-c.org/ns/1.0"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    exclude-result-prefixes="t"
+    version="2.0">
+
+  <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyzæøåöäü'" />
+  <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅÖÄÜ'" />
+  <xsl:variable name="iip_baseuri"  select="'http://kb-images.kb.dk/public/sks/'"/>
+  <xsl:variable name="iiif_suffix" select="'/full/full/0/native.jpg'"/>
+
+  <xsl:template match="t:corr">
+    <span title="rættelse">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="t:add">
+    <span title="tillæg">
+      <xsl:apply-templates/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="t:del">
+    <del title="sletning">
+      <xsl:call-template name="render_stuff"/>
+      <xsl:apply-templates/>
+    </del>
+  </xsl:template>
+
+  <xsl:template match="t:choice[t:reg and t:orig]">
+    <span>
+      <xsl:attribute name="title">
+	oprindelig: <xsl:value-of select="t:orig"/>
+      </xsl:attribute>
+      <xsl:call-template name="add_id"/>
+      <xsl:apply-templates select="t:reg"/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="t:choice[t:abbr and t:expan]">
+    <xsl:element name="a">
+      <xsl:attribute name="title">
+	<xsl:for-each select="t:expan">
+	<xsl:value-of select="."/><xsl:if test="position() &lt; last()">; </xsl:if>
+	</xsl:for-each>
+      </xsl:attribute>
+      <xsl:call-template name="add_id"/>
+      <xsl:apply-templates select="t:abbr"/>
+    </xsl:element>
+  </xsl:template>
+
+
+
+  <xsl:template match="t:ref">
+    <xsl:element name="a">
+      <xsl:if test="@type='commentary'"><xsl:attribute name="title">Kommentar</xsl:attribute></xsl:if>
+      <xsl:if test="@target">
+	<xsl:attribute name="href">
+	  <xsl:call-template name="make-href"/>
+	</xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="t:note">
+    <xsl:choose>
+      <xsl:when test="@type='commentary'">
+	<xsl:element name="p">
+	  <xsl:call-template name="add_id"/>
+	  <xsl:apply-templates select="t:label"/><xsl:text>: </xsl:text><xsl:apply-templates mode="note_body" select="t:p"/>
+	</xsl:element>
+      </xsl:when>
+      <xsl:otherwise>
+	<xsl:call-template name="inline_note"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template mode="note_body" match="t:p">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template name="add_id_empty_elem">
+    <xsl:if test="@xml:id">
+      <xsl:attribute name="id">
+	<xsl:value-of select="@xml:id"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:call-template name="render_stuff"/>
+  </xsl:template>
+
+  <xsl:template name="render_stuff">
+    <xsl:if test="contains(@rendition,'#')">
+      <xsl:variable name="rend" select="substring-after(@rendition,'#')"/>  
+      <xsl:choose>
+	<xsl:when test="$rend = 'capiTyp'"><xsl:attribute name="style">font-variant: small-caps;</xsl:attribute></xsl:when>
+	<xsl:when test="$rend = 'spa'"><xsl:attribute name="style">font-style: italic;</xsl:attribute></xsl:when>
+	<xsl:when test="/t:TEI//t:rendition[@scheme='css'][@xml:id = $rend]">
+	  <xsl:attribute name="style">
+	    <xsl:value-of select="/t:TEI//t:rendition[@scheme='css'][@xml:id = $rend]"/>
+	  </xsl:attribute>
+	</xsl:when>
+	<xsl:otherwise>
+	  <xsl:attribute name="class">
+	    <xsl:value-of select="substring-after(@rendition,'#')"/> 
+	  </xsl:attribute>
+	</xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="t:witDetail">
+    <xsl:variable name="witness"><xsl:value-of select="normalize-space(substring-after(@wit,'#'))"/></xsl:variable>
+    <xsl:element name="span">
+      <xsl:if test="@wit">
+	<xsl:attribute name="title">
+	  <xsl:value-of select="/t:TEI//t:listWit/t:witness[@xml:id=$witness]"/>
+	</xsl:attribute>
+	<xsl:value-of select="$witness"/>:
+      </xsl:if>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="t:lem">
+    <xsl:element name="span">
+      <xsl:call-template name="add_id"/>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="t:rdgGrp"> 
+    <xsl:element name="span">
+      <xsl:call-template name="add_id"/>
+      <xsl:if test="@rendition = '#semiko'">; </xsl:if><xsl:apply-templates/><xsl:comment> rdg grp </xsl:comment>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="t:app">
+    <xsl:variable name="idstring">
+      <xsl:value-of select="translate(@xml:id,'-;.','___')"/>
+    </xsl:variable>
+    <xsl:variable name="note">
+      <xsl:value-of select="concat('apparatus',$idstring)"/>
+    </xsl:variable>
+    <xsl:apply-templates select="t:lem"/>
+    <xsl:element name="sup">
+      <xsl:attribute name="style">text-indent: 0;</xsl:attribute>
+      <script>
+	var <xsl:value-of select="concat('disp',$idstring)"/>="none";
+	function <xsl:value-of select="$note"/>() {
+	var ele = document.getElementById("<xsl:value-of select="@xml:id"/>");
+	if(<xsl:value-of select="concat('disp',$idstring)"/>=="none") {
+	ele.style.display="inline";
+	<xsl:value-of select="concat('disp',$idstring)"/>="inline";
+	} else {
+	ele.style.display="none";
+	<xsl:value-of select="concat('disp',$idstring)"/>="none";
+	}
+	}
+      </script>
+      <xsl:element name="a">
+	<xsl:attribute name="title">Tekstkritik</xsl:attribute>
+	<xsl:attribute name="onclick"><xsl:value-of select="$note"/>();</xsl:attribute>
+	<i class="fa fa-info-circle" aria-hidden="true"><xsl:comment> * </xsl:comment></i>
+      </xsl:element>
+    </xsl:element>
+    <span style="background-color:Aquamarine;display:none;">
+      <xsl:call-template name="add_id"/>
+      <xsl:apply-templates select="t:rdg|t:rdgGrp|t:corr"/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="t:sic">
+  </xsl:template>
+
+  <xsl:template match="t:rdg">
+    <xsl:if test="t:sic/@rendition = '#so'"><xsl:text> Således også: </xsl:text></xsl:if>
+    <xsl:element name="span">
+      <xsl:if test="@wit">
+	<xsl:call-template name="witness"/>
+      </xsl:if><xsl:choose><xsl:when test="t:sic/@rendition = '#so'"><xsl:text> </xsl:text></xsl:when><xsl:otherwise><xsl:text>: </xsl:text></xsl:otherwise></xsl:choose>
+      <xsl:apply-templates/><xsl:if test="@evidence">[<xsl:value-of select="@evidence"/>]</xsl:if>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template name="witness">
+    <xsl:comment> Witness <xsl:value-of select="@wit"/> </xsl:comment>
+    <xsl:variable name="witnesses">
+      <xsl:copy-of select="/t:TEI//t:listWit"/>
+    </xsl:variable>
+    <xsl:for-each select="fn:tokenize(@wit,'\s+')">
+      <xsl:variable name="witness"><xsl:value-of select="normalize-space(substring-after(.,'#'))"/></xsl:variable>
+      <xsl:element name="span">
+	<xsl:attribute name="title">
+	  <xsl:value-of select="$witnesses//t:witness[@xml:id=$witness]"/>
+	</xsl:attribute>
+	<xsl:value-of select="$witness"/><xsl:choose>
+      <xsl:when test="position() &lt; last()"><xsl:text>, </xsl:text></xsl:when></xsl:choose></xsl:element>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template match="t:ptr[@type = 'author']">
+    <xsl:variable name="target">
+      <xsl:value-of select="substring-after(@target,'#')"/>
+    </xsl:variable>
+    <xsl:for-each select="/t:TEI//t:note[@xml:id = $target]">
+      <xsl:call-template name="inline_note"/>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template match="t:note[@type = 'author']"/>
+
+  <xsl:template match="t:graphic">
+    <xsl:element name="img">
+      <xsl:variable name="url">
+      <xsl:value-of select="concat($iip_baseuri,substring-before(translate(substring-after(@url,'../'),$uppercase,$lowercase),'.jpg'))"/>
+      </xsl:variable>
+      <xsl:attribute name="style"> width: 100%;</xsl:attribute>
+      <xsl:attribute name="src">
+	<xsl:value-of select="concat($url,$iiif_suffix)"/>
+      </xsl:attribute>
+      <xsl:call-template name="add_id"/>
+    </xsl:element>
+  </xsl:template>
+
+ <xsl:template match="t:figure">
+   <xsl:variable name="float_direction">
+     <xsl:choose>
+       <xsl:when test="count(preceding::t:graphic) mod 2">left</xsl:when>
+       <xsl:otherwise>right</xsl:otherwise>
+     </xsl:choose>
+   </xsl:variable>
+   <xsl:element name="div">
+      <xsl:attribute name="style"> max-width: 50%; float: <xsl:value-of select="$float_direction"/>; clear: both; margin: 2em; </xsl:attribute>
+     <xsl:call-template name="add_id"/>
+     <xsl:apply-templates select="t:graphic"/>
+     <xsl:apply-templates select="t:head"/>
+   </xsl:element>
+ </xsl:template>
+
+  <xsl:template match="t:figure/t:head">
+    <p>
+      <xsl:call-template name="add_id"/>
+      <small>
+	<xsl:apply-templates/>
+      </small>
+    </p>
+  </xsl:template>
+
+
+
+</xsl:stylesheet>

--- a/exporters/sks/render.xsl
+++ b/exporters/sks/render.xsl
@@ -6,7 +6,7 @@
 	       exclude-result-prefixes="t fn">
   
   <xsl:import href="../render-global.xsl"/>
-  <xsl:import href="../apparatus-global.xsl"/>
+  <xsl:import href="./apparatus.xsl"/>
 
   <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyzæøåöäü'" />
   <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZÆØÅÖÄÜ'" />

--- a/exporters/sks/render.xsl
+++ b/exporters/sks/render.xsl
@@ -111,10 +111,6 @@
     </xsl:element>
   </xsl:template>
 
-
-
-
-
   <xsl:template match="t:dateline/t:date">
     <span>
       <xsl:call-template name="add_id"/>

--- a/exporters/sks/render.xsl
+++ b/exporters/sks/render.xsl
@@ -54,6 +54,67 @@
     <xsl:value-of select="$year"/><xsl:if test="not(contains($date,'0000'))"> &#8211; <xsl:value-of select="substring($month_day,1,2)"/> &#8211; <xsl:value-of select="substring($month_day,3,4)"/></xsl:if>
   </xsl:template>
 
+
+
+  <xsl:template match="t:rdgGrp"> 
+    <xsl:element name="span">
+      <xsl:call-template name="add_id"/>
+      <xsl:if test="@rendition = '#semiko'">; </xsl:if><xsl:apply-templates/><xsl:comment> rdg grp </xsl:comment>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="t:app">
+    <xsl:variable name="idstring">
+      <xsl:value-of select="translate(@xml:id,'-;.','___')"/>
+    </xsl:variable>
+    <xsl:variable name="note">
+      <xsl:value-of select="concat('apparatus',$idstring)"/>
+    </xsl:variable>
+    <xsl:apply-templates select="t:lem"/>
+    <xsl:element name="sup">
+      <xsl:attribute name="style">text-indent: 0;</xsl:attribute>
+      <script>
+	var <xsl:value-of select="concat('disp',$idstring)"/>="none";
+	function <xsl:value-of select="$note"/>() {
+	var ele = document.getElementById("<xsl:value-of select="@xml:id"/>");
+	if(<xsl:value-of select="concat('disp',$idstring)"/>=="none") {
+	ele.style.display="inline";
+	<xsl:value-of select="concat('disp',$idstring)"/>="inline";
+	} else {
+	ele.style.display="none";
+	<xsl:value-of select="concat('disp',$idstring)"/>="none";
+	}
+	}
+      </script>
+      <xsl:element name="a">
+	<xsl:attribute name="title">Tekstkritik</xsl:attribute>
+	<xsl:attribute name="onclick"><xsl:value-of select="$note"/>();</xsl:attribute>
+	<i class="fa fa-info-circle" aria-hidden="true"><xsl:comment> * </xsl:comment></i>
+      </xsl:element>
+    </xsl:element>
+    <span style="background-color:Aquamarine;display:none;">
+      <xsl:call-template name="add_id"/>
+      <xsl:apply-templates select="t:rdg|t:rdgGrp|t:corr"/>
+    </span>
+  </xsl:template>
+
+  <xsl:template match="t:sic">
+  </xsl:template>
+
+  <xsl:template match="t:rdg">
+    <xsl:if test="t:sic/@rendition = '#so'"><xsl:text> Således også: </xsl:text></xsl:if>
+    <xsl:element name="span">
+      <xsl:if test="@wit">
+	<xsl:call-template name="witness"/>
+      </xsl:if><xsl:choose><xsl:when test="t:sic/@rendition = '#so'"><xsl:text> </xsl:text></xsl:when><xsl:otherwise><xsl:text>: </xsl:text></xsl:otherwise></xsl:choose>
+      <xsl:apply-templates/><xsl:if test="@evidence">[<xsl:value-of select="@evidence"/>]</xsl:if>
+    </xsl:element>
+  </xsl:template>
+
+
+
+
+
   <xsl:template match="t:dateline/t:date">
     <span>
       <xsl:call-template name="add_id"/>


### PR DESCRIPTION
The name of the pull request is a bit misleading: It is about making it possible to support different ways of linking between text, comments, introductions etc in different parts of the service. Now that works with SKS and Holberg without breaking ADL.

Here is Niels Klim in Latin and Danish
http://beta-text.kb.dk/text/holberg-niels_klim-niels_klim-root
http://beta-text.kb.dk/text/holberg-niels_klim-niels_klim_overs-root
Links to comments works for both languages but there are only facsimile for the original latin text

Enten - Eller looks as before
http://beta-text.kb.dk/text/sks-ee1-txt-root
but is a little bit different from Holberg for technical reasons.

Weverything should works with ADL data
http://beta-text.kb.dk/text/adl-texts-aare01val-root
just as before.
